### PR TITLE
feat: Add fade-in animation to features section and update initial article link for clarity

### DIFF
--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -103,3 +103,21 @@ import Container from "./Container.astro"
     </div>
   </Container>
 </div>
+
+
+<style>
+  #features {
+    animation: fadeInUp 0.7s ease-in-out forwards;
+  }
+
+  @keyframes fadeInUp {
+    from {
+      opacity: 0;
+      transform: translateY(30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0px);
+    }
+  }
+</style>

--- a/src/content/docs/blog/env-dev/2-hoja-ruta.mdx
+++ b/src/content/docs/blog/env-dev/2-hoja-ruta.mdx
@@ -14,7 +14,7 @@ import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro'
 import { Image } from 'astro:assets';
 
 <ImageZoom/>
-En nuestro artículo inicial, establecimos un problema común en la industria: la tendencia a construir rápidamente sobre cimientos frágiles. Presentamos **CodeDesignPlus** como la solución estratégica para construir sobre una base sólida desde el día uno.
+En nuestro [artículo inicial](/blog/env-dev/1-situacion-actual/), establecimos un problema común en la industria: la tendencia a construir rápidamente sobre cimientos frágiles. Presentamos **CodeDesignPlus** como la solución estratégica para construir sobre una base sólida desde el día uno.
 
 Esta página es tu mapa, el índice central de nuestra serie práctica. Aquí, transformamos la teoría en realidad, construyendo una aplicación de inventario completamente funcional, paso a paso.
 


### PR DESCRIPTION
This pull request introduces a minor enhancement to the UI and improves content clarity in the documentation. The main changes are:

Visual/UI improvements:

* Added a fade-in-up animation to the `#features` section in `Features.astro` to enhance the visual appearance when the section loads.

Documentation/content improvements:

* Updated the introduction in `2-hoja-ruta.mdx` to include a link to the initial article, making it easier for readers to navigate the blog series.