### PR TITLE
feat: Update OpenTelemetry installation guide with Helm repository addition and step renumbering for clarity

### DIFF
--- a/src/content/docs/blog/env-dev/12-install-otel.mdx
+++ b/src/content/docs/blog/env-dev/12-install-otel.mdx
@@ -190,11 +190,19 @@ Para más información, puedes consultar la [documentación oficial de OTel](htt
         Con estos ajustes, hemos adaptado exitosamente la plantilla de Grafana para un despliegue robusto y estándar.
     </Aside>
 
-2.  **Desplegar el Collector con Helm**
+2. **Agregar el Repositorio de Helm**
+    Si aún no lo has hecho, añade el repositorio oficial de OpenTelemetry Collector Contrib:
+
+    ```bash
+    helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+    helm repo update
+    ```
+
+3.  **Desplegar el Collector con Helm**
     Ahora, instalamos el OTel Collector usando su chart oficial y pasándole nuestro archivo de configuración.
 
     ```bash
-    helm install inventory opentelemetry/opentelemetry-collector `
+    helm install inventory open-telemetry/opentelemetry-collector `
         -f .\values.yaml `
         --namespace otel-collector `
         --create-namespace `
@@ -206,7 +214,7 @@ Para más información, puedes consultar la [documentación oficial de OTel](htt
 
     <Image src="/images/blogs/grafana-otel/5-grafana-otel.png" alt="Desplegando el OTel Collector con Helm" width="2550" height="1314" decoding="async" loading="lazy"/>
 
-3.  **Verificar el Despliegue en Lens**
+4.  **Verificar el Despliegue en Lens**
     *   En "Helm > Releases", vemos nuestra nueva release `inventory` en el namespace `otel-collector`.
         <Image src="/images/blogs/grafana-otel/6-grafana-otel.png" alt="Verificando la release del OTel Collector en Lens" width="2550" height="1314" decoding="async" loading="lazy"/>
     *   En "Workloads > Pods", encontramos nuestros dos pods del collector corriendo.

--- a/src/content/docs/blog/env-dev/6-microsoft-entra-external-id.mdx
+++ b/src/content/docs/blog/env-dev/6-microsoft-entra-external-id.mdx
@@ -242,46 +242,6 @@ El último paso es asegurarnos de que toda la información que necesitamos (incl
 
 </Steps>
 
-### Fase 7: Configurando Permisos de API para la Extensión
-Finalmente, nuestra extensión (`InventoryApp - CustomAuthenticationExtension`) necesita permisos para leer información de los usuarios desde Microsoft Graph API.
-
-<Steps>
-
-30. **Navegando a los Permisos de API**
-    Vamos a `App registrations`, seleccionamos nuestra app `InventoryApp - CustomAuthenticationExtension` y vamos a la sección `API permissions`.
-    <Image src="/images/blogs/microsoft-entra-external-id/59.png" alt="Navegando a API permissions" width="2550" height="1314" decoding="async" loading="lazy"/>
-
-31. **Añadiendo Permisos de Microsoft Graph**
-    Hacemos clic en `+ Add a permission`, seleccionamos `Microsoft Graph`, y luego `Application permissions`. Buscamos y añadimos los siguientes permisos:
-    *   `DeviceManagementConfiguration.Read.All` y `Write.All`
-    *   `Directory.Read.All` y `Write.All`
-    *   `Group.Read.All` y `Write.All`
-    *   `GroupMember.ReadWrite.All`
-    *   `User.EnableDisable.All`
-    *   `User.Read.All` y `Write.All`
-    <Image src="/images/blogs/microsoft-entra-external-id/60.png" alt="Añadiendo un nuevo permiso" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/61.png" alt="Seleccionando Microsoft Graph" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/62.png" alt="Seleccionando permisos de aplicación" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/63.png" alt="Añadiendo permisos DeviceManagementConfiguration" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/64.png" alt="Añadiendo permisos Directory" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/65.png" alt="Añadiendo permisos Group" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/66.png" alt="Añadiendo permisos GroupMember" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/67.png" alt="Añadiendo permisos User.EnableDisable" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/68.png" alt="Añadiendo permisos User" width="2550" height="1314" decoding="async" loading="lazy"/>
-
-32. **Otorgando Consentimiento de Administrador**
-    La lista de permisos ahora está completa, pero requieren consentimiento. Hacemos clic en `Grant admin consent for CodeDesignPlus-Dev`, confirmamos, y veremos que todos los permisos tienen el estado "Granted".
-    <Image src="/images/blogs/microsoft-entra-external-id/69.png" alt="Lista de permisos pendientes de consentimiento" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/70.png" alt="Otorgando consentimiento de administrador" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/71.png" alt="Permisos concedidos exitosamente" width="2550" height="1314" decoding="async" loading="lazy"/>
-
-33. **Creando un Secreto de Cliente**
-    Para que nuestro microservicio `ms-microsoft-graph` se autentique, necesita un secreto. Vamos a `Certificates & secrets`, creamos un `New client secret`, le damos una descripción y una duración. **¡MUY IMPORTANTE!** Copia el valor del secreto inmediatamente, ya que no volverá a mostrarse.
-    <Image src="/images/blogs/microsoft-entra-external-id/72.png" alt="Creando un nuevo secreto de cliente" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/73.png" alt="Configurando la descripción y expiración del secreto" width="2550" height="1314" decoding="async" loading="lazy"/>
-    <Image src="/images/blogs/microsoft-entra-external-id/74.png" alt="Copiando el valor del secreto de cliente" width="2550" height="1314" decoding="async" loading="lazy"/>
-
-</Steps>
 
 ## Conclusión
 


### PR DESCRIPTION
This pull request updates documentation related to the deployment of OpenTelemetry Collector with Helm and simplifies the Microsoft Entra External ID setup guide by removing detailed API permissions steps. The main focus is on improving clarity and streamlining instructions for users.

**OpenTelemetry Collector Deployment Improvements:**

* The Helm deployment instructions in `12-install-otel.mdx` have been updated to explicitly include the step of adding the OpenTelemetry Helm repository before installing the collector, making the setup process clearer and more robust.
* The deployment verification step has been renumbered to reflect the new step added for the Helm repository, maintaining logical progression in the documentation.

**Microsoft Entra External ID Documentation Simplification:**

* The detailed step-by-step guide for configuring API permissions and creating a client secret for the extension in `6-microsoft-entra-external-id.mdx` has been removed, streamlining the documentation and possibly moving these details elsewhere or assuming user familiarity.