### PR TITLE
fix: Update gateway references from istio-inventory-gateway to istio-gateway for consistency across documentation

### DIFF
--- a/src/content/docs/blog/ecosistema/10-ms-filestorage.mdx
+++ b/src/content/docs/blog/ecosistema/10-ms-filestorage.mdx
@@ -130,7 +130,7 @@ Toda la lógica de conexión y gestión de los diferentes proveedores está enca
             hosts:
               - services.codedesignplus.app
             gateways:
-              - istio-ingress/istio-inventory-gateway
+              - istio-ingress/istio-gateway
             http:
             - name: ms-filestorage
               match:

--- a/src/content/docs/blog/ecosistema/11-ms-tenant.mdx
+++ b/src/content/docs/blog/ecosistema/11-ms-tenant.mdx
@@ -106,7 +106,7 @@ El `TenantAggregate` es un agregado rico y complejo. No solo contiene la informa
             hosts:
             - services.codedesignplus.app
             gateways:
-            - istio-ingress/istio-inventory-gateway
+            - istio-ingress/istio-gateway
             http:
             - name: ms-tenants
             match:

--- a/src/content/docs/blog/ecosistema/13-ms-users.mdx
+++ b/src/content/docs/blog/ecosistema/13-ms-users.mdx
@@ -110,7 +110,7 @@ Como podemos ver, el Agregado gestiona no solo los datos básicos del usuario, s
                     hosts:
                     - services.codedesignplus.app
                     gateways:
-                    - istio-ingress/istio-inventory-gateway
+                    - istio-ingress/istio-gateway
                     http:
                     - name: ms-users
                     match:

--- a/src/content/docs/blog/ecosistema/14-ms-licenses.mdx
+++ b/src/content/docs/blog/ecosistema/14-ms-licenses.mdx
@@ -102,7 +102,7 @@ El modelo de dominio de `ms-licenses` es un ejemplo perfecto de cómo un microse
             hosts:
             - services.codedesignplus.app
             gateways:
-            - istio-ingress/istio-inventory-gateway
+            - istio-ingress/istio-gateway
             http:
             - name: ms-licenses
             match:

--- a/src/content/docs/blog/ecosistema/15-ms-microsoftgraph.mdx
+++ b/src/content/docs/blog/ecosistema/15-ms-microsoftgraph.mdx
@@ -157,7 +157,7 @@ Para que `ms-microsoftgraph` pueda interactuar con la API de Microsoft Graph, ne
                     hosts:
                     - services.codedesignplus.app
                     gateways:
-                    - istio-ingress/istio-inventory-gateway
+                    - istio-ingress/istio-gateway
                     http:
                     - name: ms-microsoftgraph
                     match:

--- a/src/content/docs/blog/ecosistema/16-tools.mdx
+++ b/src/content/docs/blog/ecosistema/16-tools.mdx
@@ -142,7 +142,7 @@ El proceso es increíblemente sencillo y se resume en tres pasos.
         "redis": "redis-standalone-headless.srv-redis.svc.cluster.local:6379",
         "virtualService": {
             "host": "services.codedesignplus.app",
-            "gateway": "istio-ingress/istio-inventory-gateway"
+            "gateway": "istio-ingress/istio-gateway"
         },
         "email": {
             "Email:TenantId": "d26654e8-c124-4126-babf-a1f18a83b864",

--- a/src/content/docs/blog/ecosistema/4-ms-catalog.mdx
+++ b/src/content/docs/blog/ecosistema/4-ms-catalog.mdx
@@ -108,7 +108,7 @@ El Agregado encapsula todos los datos y reglas de negocio para asegurar que un `
             hosts:
             - services.codedesignplus.app
             gateways:
-            - istio-ingress/istio-inventory-gateway
+            - istio-ingress/istio-gateway
             http:
             - name: ms-catalogs
             match:

--- a/src/content/docs/blog/ecosistema/5-ms-emails.mdx
+++ b/src/content/docs/blog/ecosistema/5-ms-emails.mdx
@@ -208,7 +208,7 @@ Con la configuración del proveedor de correo lista en Entra ID y los secretos r
                 hosts:
                 - services.codedesignplus.app
                 gateways:
-                - istio-ingress/istio-inventory-gateway
+                - istio-ingress/istio-gateway
                 http:
                 - name: ms-emails
                 match:

--- a/src/content/docs/blog/ecosistema/6-ms-modules.mdx
+++ b/src/content/docs/blog/ecosistema/6-ms-modules.mdx
@@ -100,7 +100,7 @@ El Agregado `ModuleAggregate` no solo contiene la información básica del módu
             hosts:
               - services.codedesignplus.app
             gateways:
-              - istio-ingress/istio-inventory-gateway
+              - istio-ingress/istio-gateway
             http:
             - name: ms-modules
               match:

--- a/src/content/docs/blog/ecosistema/7-ms-roles.mdx
+++ b/src/content/docs/blog/ecosistema/7-ms-roles.mdx
@@ -104,7 +104,7 @@ El Agregado `RoleAggregate` contiene las propiedades de un rol (como `Name` y `D
             hosts:
             - services.codedesignplus.app
             gateways:
-            - istio-ingress/istio-inventory-gateway
+            - istio-ingress/istio-gateway
             http:
             - name: ms-roles
             match:

--- a/src/content/docs/blog/ecosistema/9-ms-locations.mdx
+++ b/src/content/docs/blog/ecosistema/9-ms-locations.mdx
@@ -120,7 +120,7 @@ Como muestra el diagrama, no se trata de listas aisladas. Es un modelo relaciona
             hosts:
             - services.codedesignplus.app
             gateways:
-            - istio-ingress/istio-inventory-gateway
+            - istio-ingress/istio-gateway
             http:
             - name: ms-locations
             match:

--- a/src/content/docs/blog/env-dev/10-install-rabbitmq.mdx
+++ b/src/content/docs/blog/env-dev/10-install-rabbitmq.mdx
@@ -134,7 +134,7 @@ El tráfico de mensajería entre nuestros microservicios y RabbitMQ será intern
       hosts:
       - rabbitmq.codedesignplus.app
       gateways:
-      - istio-ingress/istio-inventory-gateway
+      - istio-ingress/istio-gateway
       http:
       - route:
         - destination:

--- a/src/content/docs/blog/env-dev/11-install-vault.mdx
+++ b/src/content/docs/blog/env-dev/11-install-vault.mdx
@@ -121,7 +121,7 @@ En esta guía, desplegaremos Vault en modo de desarrollo y realizaremos la confi
       hosts:
       - vault.codedesignplus.app
       gateways:
-      - istio-ingress/istio-inventory-gateway
+      - istio-ingress/istio-gateway
       http:
       - route:
         - destination:

--- a/src/content/docs/blog/env-dev/8-install-config-istio.mdx
+++ b/src/content/docs/blog/env-dev/8-install-config-istio.mdx
@@ -158,7 +158,7 @@ Istio se instala en varios componentes. Usaremos Helm para desplegarlos de forma
     apiVersion: networking.istio.io/v1
     kind: Gateway
     metadata:
-      name: istio-inventory-gateway
+      name: istio-gateway
       namespace: istio-ingress
     spec:
       selector:
@@ -182,7 +182,7 @@ Istio se instala en varios componentes. Usaremos Helm para desplegarlos de forma
     apiVersion: networking.istio.io/v1
     kind: Gateway
     metadata:
-      name: istio-inventory-gateway
+      name: istio-gateway
       namespace: istio-ingress
     spec:
       selector:
@@ -208,7 +208,7 @@ Istio se instala en varios componentes. Usaremos Helm para desplegarlos de forma
     <Image src="/images/blogs/install-config-istio/13.png" alt="Aplicando el manifiesto del Gateway de Istio" width="2550" height="1314" decoding="async" loading="lazy"/>
 
 4.  **Verificar la Creación del Gateway**
-    En Lens, si vamos a la sección de recursos de Istio (`Network > Gateway`), veremos nuestro `istio-inventory-gateway` creado correctamente.
+    En Lens, si vamos a la sección de recursos de Istio (`Network > Gateway`), veremos nuestro `istio-gateway` creado correctamente.
 
     <Image src="/images/blogs/install-config-istio/14.png" alt="Verificando la creación del recurso Gateway en Lens" width="2550" height="1314" decoding="async" loading="lazy"/>
 
@@ -353,7 +353,7 @@ Esta sección asume una comprensión básica de los manifiestos de Kubernetes (`
       hosts:
       - services.codedesignplus.app
       gateways:
-      - istio-ingress/istio-inventory-gateway
+      - istio-ingress/istio-gateway
       http:
       - name: snake
         match:
@@ -374,7 +374,7 @@ Esta sección asume una comprensión básica de los manifiestos de Kubernetes (`
     *   **`Service`**: Crea un punto de acceso interno y estable para nuestros pods de Snake. Le da un nombre DNS dentro del clúster (`snake.snake-test.svc.cluster.local`).
     *   **`VirtualService`**: Este es el "director de tráfico" de Istio. Le damos las siguientes instrucciones:
         *   **`hosts`**: Aplica esta regla cuando el tráfico llegue al host `services.codedesignplus.app`.
-        *   **`gateways`**: Asocia esta regla con el `istio-inventory-gateway` que creamos anteriormente.
+        *   **`gateways`**: Asocia esta regla con el `istio-gateway` que creamos anteriormente.
         *   **`match`**: Si la URL empieza con `/snake/`.
         *   **`rewrite`**: Antes de enviar el tráfico al servicio, reescribe la URL a `/` (ya que la aplicación de Snake no espera `/snake/`).
         *   **`route`**: Envía el tráfico al `Service` de Kubernetes `snake` en el namespace `snake-test`.


### PR DESCRIPTION
This pull request updates the Istio gateway configuration across multiple documentation files to standardize the gateway name from `istio-inventory-gateway` to `istio-gateway`. This change ensures consistency in the documentation and aligns all references with the new gateway naming convention.

**Istio Gateway Naming Standardization:**

* Updated all references of `istio-inventory-gateway` to `istio-gateway` in the Istio gateway and virtual service manifests, as well as in related documentation and code snippets. [[1]](diffhunk://#diff-dd23dd498ae91fb12f773bc4c8b3bfed1ac75ae2f8aeeb1b2924211971a13130L161-R161) [[2]](diffhunk://#diff-dd23dd498ae91fb12f773bc4c8b3bfed1ac75ae2f8aeeb1b2924211971a13130L185-R185) [[3]](diffhunk://#diff-dd23dd498ae91fb12f773bc4c8b3bfed1ac75ae2f8aeeb1b2924211971a13130L211-R211) [[4]](diffhunk://#diff-dd23dd498ae91fb12f773bc4c8b3bfed1ac75ae2f8aeeb1b2924211971a13130L356-R356) [[5]](diffhunk://#diff-dd23dd498ae91fb12f773bc4c8b3bfed1ac75ae2f8aeeb1b2924211971a13130L377-R377) [[6]](diffhunk://#diff-d716905df55cb50b307a69507e0ca2740e6c1266d1492adc38468802802a6f65L137-R137) [[7]](diffhunk://#diff-38751cdf093463311c03a2c3aa8f6e16cd2b089ff69dcd2b290ac8d012686230L124-R124)

**Microservices Documentation Updates:**

* Changed the gateway reference to `istio-gateway` in example configurations for various microservices, including file storage, tenants, users, licenses, Microsoft Graph, catalogs, emails, modules, roles, and locations. [[1]](diffhunk://#diff-c922656fb9a73e31062b8e930c0c1d3507b0ea3da4e8ff74c68806e98f7bbc05L133-R133) [[2]](diffhunk://#diff-1b2f7d585aa6a838cd0683e1e66b45a613470b654a95893314ed68f355b96fdfL109-R109) [[3]](diffhunk://#diff-92521065741891b3a4ea068ec3f407c70640c37086df847ad1785cfe7cb75f3dL113-R113) [[4]](diffhunk://#diff-7871584fe67a3611f369a939f6bdcf4126491fcb7ed5c6ee6447ca227fcc0e5aL105-R105) [[5]](diffhunk://#diff-fd55433c6d9ede11d8258f6c50585346bd770ad4b9a7e3a4a8641165522aa179L160-R160) [[6]](diffhunk://#diff-91794bc7daf7837608b0f80768d00c39401be283d24885ee954bfe84721fa076L111-R111) [[7]](diffhunk://#diff-2b9580119d6e316a64026b02463e912e65fdd295064cef12013740bbc52aec4eL211-R211) [[8]](diffhunk://#diff-ddf239b15a33b7d8ae32057ebf84f09bb4150c507aff619bf8258c3aff0695efL103-R103) [[9]](diffhunk://#diff-15eede9539313601d9d19cd6fdf89984d73e424d70db1d9244805ee20a3cd40cL107-R107) [[10]](diffhunk://#diff-fd4c20d2ddc93d4f81cd5dfcbbbb4f2bb3f7e20ebd10b727bf332daf48fa1e22L123-R123)

**Tools and Example Configuration Updates:**

* Updated sample configuration objects and code blocks referencing the gateway in tool and environment documentation to use the new gateway name.

These changes help prevent confusion for users following the documentation and ensure that all manifests and examples are up to date with the current infrastructure naming conventions.